### PR TITLE
Making the value parameter optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,14 +11,17 @@ exports.register = function(server, options, next) {
       }
       return;
     }
+    const payload = {
+      type,
+      tags,
+      fields
+    };
+    if (value) {
+      payload.value = value;
+    }
     wreck.post(url.resolve(options.host, '/api/track'), {
       json: true,
-      payload: JSON.stringify({
-        type,
-        tags,
-        value,
-        fields
-      })
+      payload: JSON.stringify(payload)
     }, (err, resp, payload) => {
       if (err) {
         sever.log(['micro-metrics', 'error'], err);


### PR DESCRIPTION
Pass either `null` or `false` to the value to skip passing the value to micro-metrics. 